### PR TITLE
Update to use operatingsystemmajrelease and do Integer comparison

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ssh::params {
   # useprivilegeseparation is only available on openssh 5.8 and later
   case $::operatingsystem {
     'Redhat', 'CentOS', 'Scientific', 'Debian': {
-      if $::operatingsystemrelease < '7' {
+      if $::operatingsystemmajrelease < 7 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'
@@ -29,7 +29,7 @@ class ssh::params {
 
     }
     'Ubuntu': {
-      if $::operatingsystemrelease < '12' {
+      if $::operatingsystemmajrelease < 12 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'


### PR DESCRIPTION
When running a Debian Squeeze (6.0.7) client against a Debian Wheezy (7.1) master
received the following error:

comparison of String with 7 failed at /etc/puppet/modules/ssh/manifests/params.pp:24

Removing quotes to treat as Integer comparison rather than String and using only the
major release fact to compare against rather than potential multi-decimal version
