### PR TITLE
Ubuntu bug fix

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class ssh::params {
 
     }
     'Ubuntu': {
-      if $::operatingsystemmajrelease < 12 {
+      if $::lsbmajdistrelease < 12 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'


### PR DESCRIPTION
I am on Ubuntu v12.04 LTS and I get the following error:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: undefined method `<' for :undef:Symbol at /etc/puppet/modules/ssh/manifests/params.pp:32 on node my server

Because the fact "operatingsystemmajrelease" is undefined on Ubuntu.  The correct fact is "lsbmajdistrelease"
# facter operatingsystemmajrelease
# 
# facter lsbmajdistrelease

12
