### PR TITLE
Allow authorized keys file conf

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,7 @@ The following options are set in the default server options parameter
 - GSSAPIAuthentication            => yes
 - GSSAPICleanupCredentials        => yes
 - X11Forwarding                   => yes
+- AuthorizedKeysFile              => .ssh/authorized_keys
 
 The following options are set in the default client options parameter
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@
 #   - GSSAPIAuthentication yes
 #   - GSSAPICleanupCredentials yes
 #   - X11Forwarding yes
+#   - AuthorizedKeysFile .ssh/authorized_keys
 #
 # [ *clientoptions*]
 #   This hash contains all ssh_config options. The following options are set
@@ -51,6 +52,7 @@ class ssh (
     'GSSAPIAuthentication'            => 'yes',
     'GSSAPICleanupCredentials'        => 'yes',
     'X11Forwarding'                   => 'yes',
+    'AuthorizedKeysFile'              => '.ssh/authorized_keys',
   }
   $defaultclientoptions = {
     'ForwardX11Trusted'    => 'yes',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,6 @@ class ssh::params {
       } else {
         $useprivilegeseparation = 'sandbox'
       }
-
     }
     'Ubuntu': {
       if $::operatingsystemmajrelease < 12 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ssh::params {
   # useprivilegeseparation is only available on openssh 5.8 and later
   case $::operatingsystem {
     'Redhat', 'CentOS', 'Scientific', 'Debian': {
-      if $::operatingsystemmajrelease < 7 {
+      if $::lsbmajrelease < 7 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'
@@ -34,6 +34,9 @@ class ssh::params {
       } else {
         $useprivilegeseparation = 'sandbox'
       }
+    }
+    'XenServer': {
+      $useprivilegeseparation = 'yes'
     }
     default: {
       $useprivilegeseparation = 'sandbox'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ssh::params {
   # useprivilegeseparation is only available on openssh 5.8 and later
   case $::operatingsystem {
     'Redhat', 'CentOS', 'Scientific', 'Debian': {
-      if $::lsbmajrelease < 7 {
+      if $::operatingsystemmajrelease < 7 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -51,10 +51,6 @@ SyslogFacility AUTHPRIV
 #RSAAuthentication yes
 #PubkeyAuthentication yes
 
-# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
-# but this is overridden so installations will only check .ssh/authorized_keys
-AuthorizedKeysFile	.ssh/authorized_keys
-
 #AuthorizedKeysCommand none
 #AuthorizedKeysCommandUser nobody
 


### PR DESCRIPTION
Allow to configure AuthorizedKeysFile, default to .ssh/authorized_keys to be backward compatible.