### PR TITLE
operatingsystemmajrelease -> lsbmajrelease for facter 1.7.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,7 @@ ssh::config have a config_template parameter to change the template file.
 
 - puppetlabs/stdlib >= 3.0.0
 - ripienarr/concat >= 0.2.0
+- facter >= 1.7.4
 
 # OS
 - RedHat and Debian OS family are supported.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class ssh::params {
   # useprivilegeseparation is only available on openssh 5.8 and later
   case $::operatingsystem {
     'Redhat', 'CentOS', 'Scientific', 'Debian': {
-      if $::operatingsystemmajrelease < 7 {
+      if $::lsbmajdistrelease < 7 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'
@@ -29,7 +29,7 @@ class ssh::params {
 
     }
     'Ubuntu': {
-      if $::operatingsystemmajrelease < 12 {
+      if $::lsbmajdistrelease < 12 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'


### PR DESCRIPTION
This should fix issues #9 and #11. On Debian based machines with the latest facter 1.7.4, operatingsystemmajrelease is now lsbmajrelease. I've updated the readme and params accordingly, and it works on my machine :)
