### PR TITLE
Fixing test for Ubuntu OS version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class ssh::params {
 
     }
     'Ubuntu': {
-      if $::operatingsystemmajrelease < 12 {
+      if $::lsbmajdistrelease < 12 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'


### PR DESCRIPTION
facter variable name is wrong for Ubuntu. See https://github.com/spiette/puppet-ssh/issues/9.
Testing on an Ubuntu node with both facter 1.7.3 and 1.7.4, the variable name that holds this value is lsbmajdistrelease in both. Neither returned a value for operatingsystemmajrelease.
I'm now running a modified version of this module that uses lsbmajdistrelease in place of operatingsystemmajrelease for Ubuntu. I've submitted a pull request with this change, but I've only tested with these versions of facter, with Ubuntu 12.04, CentOS 6.5 and Debian 7.3.