### PR TITLE
Multiple matches

### DIFF
--- a/manifests/match.pp
+++ b/manifests/match.pp
@@ -6,30 +6,42 @@
 # == Parameters
 #
 # [*type*]
-#   Object type affected by the following options.
+#   Depreciated. For backwards-compatibility, this parameter defines the object type in a single match condition.
 #
 # [*pattern*]
-#   Pattern to be matched against. Defaults to $name
+#   Depreciated. When matching on a single condition, the pattern to be matched against. Defaults to $name
 #
+# [*conditions*]
+#   A hash of type/pattern pairs to use in matching on multiple conditions. Has no effect, if $type is defined.
+# 
 # [*options*]
 #   A hash of options to set for the user. Defaults to {}. Will fail if empty.
 #
-define ssh::match ($type, $options, $pattern=$name) {
-  include ssh
-  if $type in [
+define ssh::match (
+  $type       = undef,
+  $pattern    = $name,
+  $conditions = undef,
+  $options,
+) {
+  if $type != undef and !($type in [
     'user',
     'group',
     'host',
     'localaddress',
     'localport',
     'address',
-  ] {
-    concat::fragment { "ssh_match_${type}_${pattern}":
+  ]) {
+    fail("Unknown type match: ${type}")
+  } elsif $type == undef and $conditions == undef {
+    fail("Either \$type or \$conditions must be specified.") 
+  } elsif $conditions != undef and !(is_hash($conditions)) {
+    fail("\$conditions must be an array")
+  } else {
+    include ssh
+    concat::fragment { "ssh_match_${name}":
       target  => $ssh::params::conffile,
       order   => 20,
       content => template('ssh/sshd_config_match.erb')
     }
-  } else {
-    fail("Unknown type match: ${type}")
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class ssh::params {
 
     }
     'Ubuntu': {
-      if $::operatingsystemmajrelease < 12 {
+      if $::lsbmajdistrelease < 12 {
         $useprivilegeseparation = 'yes'
       } else {
         $useprivilegeseparation = 'sandbox'

--- a/templates/sshd_config_match.erb
+++ b/templates/sshd_config_match.erb
@@ -1,5 +1,12 @@
-Match <%= @type %> <%= @pattern -%>
-<% @options.keys.sort.each do | key | %>
-    <%= key %> <%= @options[key] -%>
+<% if @type -%>
+<%=  "Match #{@type} #{@pattern}" -%>
+<% else -%>
+<%=  "Match" -%>
+<%   @conditions.keys.sort.each do |type| -%>
+<%=    " #{type} #{@conditions[type]}" -%>
+<%   end -%>
+<% end -%>
+<% @options.keys.sort.each do | key | -%>
+<%= "\n    #{key} #{@options[key]}" -%>
 <% end %>
 


### PR DESCRIPTION
Hi Spiette, your module helped me out of a hole, as I was having trouble with role and user-specific ssh configs. There's many ssh modules out there, but not many allowed for arbitrary match statements, as yours does. Something missing, though: ssh::match, as it is, only supports matching on single condition. I've extended this to support matching on multiple conditions of different types. To avoid introducing breaking changes, I've added an additional hash parameter to the define and amended the template to use either this or the origin type/pattern parameters.
Sound good?