### PR TITLE
params.pp: XenServer is based on CentOS <= 6.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,9 @@ class ssh::params {
       }
 
     }
+    'XenServer': {
+      $useprivilegeseparation = 'yes'
+    }
     'Ubuntu': {
       if versioncmp($::operatingsystemrelease, '12') < 0 {
         $useprivilegeseparation = 'yes'


### PR DESCRIPTION
Hi,
XenServer is based on CentOS 5 and latest XenServer (6.5) on CentOS 6, so sandbox privilege separation is not available. Default might also be less "strict/recent" by being yes in place of sandbox.
Thanks.
